### PR TITLE
Add __test__ = False to VS Code test examples file

### DIFF
--- a/frame-check-extensions/vscode/test-examples/dataframe_test.py
+++ b/frame-check-extensions/vscode/test-examples/dataframe_test.py
@@ -188,3 +188,6 @@ if __name__ == "__main__":
     test_dataframe_operations()
 
     print("Test file execution complete!")
+
+# Exclude from pytest collection
+__test__ = False


### PR DESCRIPTION
- Currently, running pytest at project root collects the file `frame-check-extensions/vscode/test-examples/dataframe_test.py`, which is actually just a demo test file.
- Added `__test__ = False` to exclude it from Pytest collection