### PR TITLE
fix: type error in _get_cols_from_data_arg

### DIFF
--- a/frame-check-core/src/frame_check_core/_models.py
+++ b/frame-check-core/src/frame_check_core/_models.py
@@ -30,7 +30,7 @@ class FrameInstance:
         if isinstance(arg.val, ast.Assign) and isinstance(arg.val.value, ast.Dict):
             inner_dict = WrappedNode(arg.val.value)
             keys = inner_dict.get("keys")
-            return [key.value for key in keys.val] if keys.val is not None else []
+            return [str(key.value) for key in keys.val] if keys.val is not None else []
         return []
 
     def add_columns(self, *columns: str | WrappedNode[str]):


### PR DESCRIPTION
The _get_cols_from_data_arg method in FrameInstance has a mismatch in types (list[_ConstantValue] | list[str]) for the following line. 

```python
return [key.value for key in keys.val] if keys.val is not None else [] 
```

The proposed change explicitly casts key.value to a String to match the return type of the method

```python
return [str(key.value) for key in keys.val] if keys.val is not None else []
```