### PR TITLE
chore: Add pre-commit.ci configuration options

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,14 @@ repos:
         args: [--fix]
       # Run the formatter.
       - id: ruff-format
+ci:
+  autofix_commit_msg: |
+    [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+    for more information, see https://pre-commit.ci
+  autofix_prs: true
+  autoupdate_branch: ""
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
+  autoupdate_schedule: weekly
+  skip: []
+  submodules: false


### PR DESCRIPTION
Enable automatic fixes, PRs, and weekly autoupdates for pre-commit hooks. Set skip and submodules options to default values.