### PR TITLE
[FEATURE] check multiple files in CLI

### DIFF
--- a/frame-check-core/src/frame_check_core/__init__.py
+++ b/frame-check-core/src/frame_check_core/__init__.py
@@ -248,7 +248,7 @@ class FrameChecker(ast.NodeVisitor):
 
 def create_parser() -> argparse.ArgumentParser:
     """Create and configure the argument parser for frame-check CLI.
-    
+
     Returns:
         Configured ArgumentParser instance.
     """
@@ -257,43 +257,44 @@ def create_parser() -> argparse.ArgumentParser:
         description="A static checker for dataframes!",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    
+
     parser.add_argument(
         "files",
         type=str,
         nargs="*",
         help="Python files, directories, or glob patterns to check. "
-             "If not specified, checks all .py files in current directory.",
+        "If not specified, checks all .py files in current directory.",
     )
-    
+
     parser.add_argument(
-        "-v", "--version",
+        "-v",
+        "--version",
         action="version",
         version="%(prog)s 0.1.0",
     )
-    
+
     return parser
 
 
 def collect_python_files(paths: list[str]) -> list[Path]:
     """Collect all Python files from the given paths.
-    
+
     Args:
         paths: List of file paths, directory paths, or glob patterns.
                If empty, defaults to all .py files in current directory recursively.
-    
+
     Returns:
         List of Path objects for Python files to check.
     """
     if not paths:
         # Default: all .py files in current directory and subdirectories (recursive)
         return sorted(Path.cwd().rglob("*.py"))
-    
+
     collected_files: set[Path] = set()
-    
+
     for path_str in paths:
         path = Path(path_str)
-        
+
         if path.is_file() and path.suffix == ".py":
             collected_files.add(path.resolve())
         elif path.is_dir():
@@ -305,7 +306,7 @@ def collect_python_files(paths: list[str]) -> list[Path]:
                 matched = Path(matched_path)
                 if matched.is_file() and matched.suffix == ".py":
                     collected_files.add(matched.resolve())
-    
+
     return sorted(collected_files)
 
 
@@ -313,17 +314,17 @@ def main(argv: list[str] | None = None) -> int:
     """Main entry point for the CLI."""
     parser = create_parser()
     args = parser.parse_args(argv)
-    
+
     # Collect all Python files to check
     python_files = collect_python_files(args.files)
-    
+
     if not python_files:
         print("No Python files found to check.", file=sys.stderr)
         return 0
-    
+
     # Track if any file has diagnostics
     has_errors = False
-    
+
     # Process each file
     for file_path in python_files:
         try:
@@ -331,12 +332,12 @@ def main(argv: list[str] | None = None) -> int:
             if fc.diagnostics:
                 has_errors = True
                 print_diagnostics(fc, str(file_path))
-            
+
         except SyntaxError as e:
             print(f"Syntax error in {file_path}:\n{e}", file=sys.stderr)
             has_errors = True
         except Exception as e:
             print(f"Error checking {file_path}:\n{e}", file=sys.stderr)
             has_errors = True
-    
+
     return 1 if has_errors else 0


### PR DESCRIPTION
Closes #27 

## What's Changed
- Used built-in argparse package to parse cli args replacing sys.args[0] etc.
- More informational usage information
- Allows glob pattern when specifying files
  - `frame-check` with no file name check all `.py` files (recursively) under current directory
  - `frame-check foo.py`, frame-check foo.py bar.py baz.py`, `frame-check *.py` all works
  - `frame-check dir/` checks content of directory
  