### PR TITLE
Added hyperlink to  wordings in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,5 +123,5 @@ Each component should then have a README.md file with instructions on how to run
 
  ---
 
- Born at PyconHK 2025
+ Born at [PyconHK 2025](https://pycon.hk/)
  ![](https://pycon.hk/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Flogo.ebd84d16.png&w=256&q=75)


### PR DESCRIPTION
This small PR is to add a hyperlink to the `PyCon HK 2025` wordings in the README, in order to enhance the visibility of PyCon HK and promote the culture of Sprint in the future.