### PR TITLE
Fixing wrong ast input test, and added branch checking validation

### DIFF
--- a/frame-check-core/tests/test_check_method.py
+++ b/frame-check-core/tests/test_check_method.py
@@ -68,7 +68,7 @@ result = df['Z']
     checker = FrameChecker.check(test_file)
     assert len(checker.column_accesses) == 1
     assert checker.column_accesses.contains_id("Z")
-    
+
     mock_fd = MagicMock()
     mock_fd.__enter__().read.return_value = code
     # Ensure the correct branch is taken
@@ -79,7 +79,7 @@ result = df['Z']
         checker = FrameChecker.check(test_file)
         # Ensure both the AST parse method and file open method are called
         mock_ast_parse.assert_called_once_with(code)
-        mock_open.assert_called_once_with(str(test_file), 'r')
+        mock_open.assert_called_once_with(str(test_file), "r")
         mock_fd.__enter__().read.assert_called_once()
 
 


### PR DESCRIPTION
This small PR does the following:
1. Fixing the wrong test for `test_check_with_ast_input` where the input is still a `str` type not an `ast.Module` type
2. Using `unittest.mock.patch` to validate the correct path has been called inside the `check` function, whether or not the input has been treated as a file to open and parsed by the `ast` module.