### PR TITLE
fix: Replace typing_extensions import with typing for TYPE_CHECKING

### DIFF
--- a/frame-check-core/src/frame_check_core/util/message.py
+++ b/frame-check-core/src/frame_check_core/util/message.py
@@ -1,4 +1,4 @@
-from typing_extensions import TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..frame_checker import FrameChecker


### PR DESCRIPTION
When I install `frame-check` and run it outside the dev environment I get this
<img width="1924" height="336" alt="image" src="https://github.com/user-attachments/assets/56d3fa94-5ef2-4f53-91e3-30249aec6b28" />

We can just use `typing` for this