### PR TITLE
Add support tracking for features and update test markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,22 @@ uv run pre-commit install
 ```
 Each component should then have a README.md file with instructions on how to run it.
 
- ---
+## Supported Features
+
+| feature_code                    | name                        | example                                                          | supported   |
+|:--------------------------------|:----------------------------|:-----------------------------------------------------------------|:------------|
+| <a id="#CAM-1"></a>#CAM-1       | Direct column assignment    | df["c"] = [7, 8, 9]                                              | ✅          |
+| <a id="#CAM-10"></a>#CAM-10     | Set Item with list          | df[["c", "d"]] = [[7, 8, 9], [10, 11, 12]]                       | ✅          |
+| <a id="#CAM-7"></a>#CAM-7       | df.assign                   | df.assign(A=[1, 2, 3])                                           | ❌          |
+| <a id="#CAM-7-1"></a>#CAM-7-1   | df.assign + subscript       | df.assign(A=[1, 2, 3])['A']                                      | ✅          |
+| <a id="#CAM-7-2"></a>#CAM-7-2   | df.assign chaining          | df.assign(A=[1, 2, 3]).assign(B=[4, 5, 6])                       | ❌          |
+| <a id="#CAM-9"></a>#CAM-9       | df.insert                   | df.insert(0, "A", [1, 2, 3])                                     | ✅          |
+| <a id="#DCMS-6"></a>#DCMS-6     | read_csv + usecols inline   | df = pd.read_csv('file.csv', usecols=['a', 'b', 'c'])            | ✅          |
+| <a id="#DCMS-6-1"></a>#DCMS-6-1 | read_csv + usecols indirect | cols=['a', 'b', 'c']; df = pd.read_csv('file.csv', usecols=cols) | ✅          |
+
+Note: some not-supported features may not be present in this list
+
+---
 
  Born at [PyconHK 2025](https://pycon.hk/)
  ![](https://pycon.hk/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Flogo.ebd84d16.png&w=256&q=75)

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,179 @@
+import inspect
+import os
+import re
+from typing import NamedTuple
+
+import pandas as pd
+import pytest
+
+
+# Store test results
+class SupportResult(NamedTuple):
+    feature_code: str
+    name: str
+    example: str
+    supported: bool
+
+
+_support_results: list[SupportResult] = []
+
+
+def pytest_addoption(parser):
+    """Add --support command line option."""
+    parser.addoption(
+        "--support",
+        action="store_true",
+        default=False,
+        help="Generate feature support documentation",
+    )
+
+
+def pytest_configure(config):
+    """Register the support marker."""
+    config.addinivalue_line(
+        "markers", "support(name): mark test to track feature support status"
+    )
+
+
+def extract_example_from_test(item):
+    """Extract the code example from test function, skipping first two lines."""
+    try:
+        # Get the test function source code
+        source = inspect.getsource(item.function)
+
+        # Find the `code = """` block
+        lines = source.split("\n")
+
+        # Find start of triple-quoted string
+        start_idx = None
+        for i, line in enumerate(lines):
+            if 'code = """' in line or "code = '''" in line:
+                start_idx = i + 1  # Start after the opening line
+                break
+
+        if start_idx is None:
+            return "N/A"
+
+        # Find end of triple-quoted string
+        end_idx = None
+        for i in range(start_idx, len(lines)):
+            if '"""' in lines[i] or "'''" in lines[i]:
+                end_idx = i
+                break
+
+        if end_idx is None:
+            return "N/A"
+
+        # Extract the code lines
+        code_lines = lines[start_idx:end_idx]
+
+        # Skip first two lines (import pandas and DataFrame creation)
+        if len(code_lines) > 2:
+            example_lines = code_lines[2:]
+            # Remove leading whitespace and join
+            example = "\n".join(line.strip() for line in example_lines if line.strip())
+            return example
+
+        return "N/A"
+
+    except Exception:
+        return "N/A"
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Capture test results for tests marked with @support."""
+    outcome = yield
+    report = outcome.get_result()
+
+    # Only collect if --support flag is enabled
+    if not item.config.getoption("--support"):
+        return
+
+    # Only process the 'call' phase (actual test execution, not setup/teardown)
+    if report.when == "call":
+        # Check if test has the support marker
+        support_marker = item.get_closest_marker("support")
+        if support_marker:
+            # Get the feature name from the marker
+            feature_name = support_marker.kwargs.get("name", item.name)
+
+            feature_code = support_marker.kwargs.get("code", "")
+
+            # Try to get example from marker, otherwise extract from code
+            feature_example = support_marker.kwargs.get(
+                "example", extract_example_from_test(item)
+            )
+
+            # Store whether the test passed
+            _support_results.append(
+                SupportResult(
+                    feature_code,
+                    feature_name,
+                    feature_example,
+                    report.outcome == "passed",
+                )
+            )
+
+
+def update_readme(df: pd.DataFrame):
+    """
+    Update readme support table
+    Update section under ## Supported Features header
+    """
+    readme_path = "README.md"
+    if not os.path.exists(readme_path):
+        print(f"Warning: {readme_path} not found, skipping update.")
+        return
+
+    # Read the README content
+    with open(readme_path, "r") as f:
+        content = f.read()
+
+    # Find the supported features section
+    support_section_pattern = r"## Supported Features\s*\n(.*?)\n---"
+    match = re.search(support_section_pattern, content, re.DOTALL)
+    if not match:
+        print("Warning: Could not find '## Supported Features' section in README.md")
+        return
+
+    # Format the table
+    df["feature_code"] = '<a id="' + df["feature_code"] + '"></a>' + df["feature_code"]
+    table = df.replace({True: "✅", False: "❌"}).to_markdown(index=False)
+
+    # Replace the section with new content
+    new_section = f"## Supported Features\n\n{table}\n\nNote: some not-supported features may not be present in this list\n\n---"
+    new_content = re.sub(support_section_pattern, new_section, content, flags=re.DOTALL)
+
+    # Write back to README
+    with open(readme_path, "w") as f:
+        f.write(new_content)
+
+    print(f"Updated support table in {readme_path}")
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Write support results to a file after all tests complete."""
+    # Only write report if --support flag is enabled
+    if not session.config.getoption("--support"):
+        return
+
+    if not _support_results:
+        print("\nNo @support marked tests found.")
+        return
+
+    import pandas as pd
+
+    df = pd.DataFrame(_support_results).sort_values(
+        ["feature_code", "name", "example"]  # Sort for consistency
+    )
+
+    print()
+    print("\n" + "=" * 24)
+    print("Feature Support Summary:")
+    print()
+    print(df.to_markdown(index=False, tablefmt="rounded_grid"))
+    print()
+
+    # Update the README.md file with support information
+    update_readme(df)

--- a/frame-check-core/tests/test_call.py
+++ b/frame-check-core/tests/test_call.py
@@ -1,8 +1,10 @@
 import pytest
-
 from frame_check_core import FrameChecker
 
 
+@pytest.mark.support(
+    name="df.insert", code="#CAM-9", example='df.insert(0, "A", [1, 2, 3])'
+)
 def test_insert():
     code = """
 import pandas as pd
@@ -16,6 +18,7 @@ df["A"]
     assert len(fc.diagnostics) == 0
 
 
+@pytest.mark.support(name="df.assign", code="#CAM-7", example="df.assign(A=[1, 2, 3])")
 @pytest.mark.xfail(reason="Not implemented")
 def test_assign_create():
     code = """
@@ -30,6 +33,9 @@ df["A"]
     assert len(fc.diagnostics) == 0
 
 
+@pytest.mark.support(
+    name="df.assign + subscript", code="#CAM-7-1", example="df.assign(A=[1, 2, 3])['A']"
+)
 @pytest.mark.xfail(reason="Not implemented")
 def test_assign_subscript():
     code = """
@@ -41,6 +47,11 @@ df.assign(A=[1, 2, 3])["A"]
     assert len(fc.diagnostics) == 0
 
 
+@pytest.mark.support(
+    name="df.assign chaining",
+    code="#CAM-7-2",
+    example="df.assign(A=[1, 2, 3]).assign(B=[4, 5, 6])",
+)
 @pytest.mark.xfail(reason="Not implemented")
 def test_assign_chain():
     code = """

--- a/frame-check-core/tests/test_check_method.py
+++ b/frame-check-core/tests/test_check_method.py
@@ -1,6 +1,7 @@
 import ast
-from frame_check_core import FrameChecker
 from unittest.mock import MagicMock, patch
+
+from frame_check_core import FrameChecker
 
 
 def test_check_with_string_input():

--- a/frame-check-core/tests/test_column_assignment.py
+++ b/frame-check-core/tests/test_column_assignment.py
@@ -1,10 +1,11 @@
+import pytest
 from frame_check_core import FrameChecker
 
 
+@pytest.mark.support(name="Direct column assignment", code="#CAM-1")
 def test_direct_column_assignment():
     code = """
 import pandas as pd
-
 df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
 df["c"] = [7, 8, 9]
 """
@@ -14,6 +15,7 @@ df["c"] = [7, 8, 9]
     assert df.columns == ["a", "b", "c"]
 
 
+@pytest.mark.support(name="Set Item with list", code="#CAM-10")
 def test_list_column_assignment():
     code = """
 import pandas as pd

--- a/frame-check-core/tests/test_read_csv.py
+++ b/frame-check-core/tests/test_read_csv.py
@@ -1,9 +1,16 @@
-from frame_check_core import FrameChecker
 from pathlib import Path
+
+import pytest
+from frame_check_core import FrameChecker
 
 CSV_TEST_FILE = Path(__file__) / "data" / "csv_file.csv"
 
 
+@pytest.mark.support(
+    name="read_csv + usecols inline",
+    code="#DCMS-6",
+    example="df = pd.read_csv('file.csv', usecols=['a', 'b', 'c'])",
+)
 def test_read_csv_usecols():
     code = f"""
 import pandas as pd
@@ -19,6 +26,11 @@ df = pd.read_csv("{CSV_TEST_FILE}", usecols=['a', 'b', 'c'])
     assert frame_instance.lineno == 4
 
 
+@pytest.mark.support(
+    name="read_csv + usecols indirect",
+    code="#DCMS-6-1",
+    example="cols=['a', 'b', 'c']; df = pd.read_csv('file.csv', usecols=cols)",
+)
 def test_read_csv_usecols_indirect():
     code = f"""
 import pandas as pd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "pre-commit>=4.3.0",
     "pytest>=8.4.2",
     "pytest-codspeed>=4.1.1",
+    "tabulate>=0.9.0",
     "types-psutil>=7.0.0.20250822",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -209,6 +209,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-codspeed" },
+    { name = "tabulate" },
     { name = "types-psutil" },
 ]
 
@@ -228,6 +229,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-codspeed", specifier = ">=4.1.1" },
+    { name = "tabulate", specifier = ">=0.9.0" },
     { name = "types-psutil", specifier = ">=7.0.0.20250822" },
 ]
 
@@ -951,6 +953,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Relates #57  #58 

This PR introduces a "docs-as-test" approach to dynamically fill the support matrix using existing tests.

## How

By using `@pytest.mark.support` decorator on top of the tests, this will be recognized as a "support" proof for the feature we are  implementing. 
Example:
```python
@pytest.mark.support(name="Direct column assignment", code="#CAM-1")
def test_direct_column_assignment():
    code = """
import pandas as pd
df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
df["c"] = [7, 8, 9]
"""
    fc = FrameChecker.check(code)
    dfs = fc.frames.get("df")
    df = dfs[-1]
    assert df.columns == ["a", "b", "c"]
```

As expected, if the tests fails, the feature  will be marked as not supported.
We can run the tests with the `--support` flag

Which will show this ouput
<img width="1984" height="1443" alt="image" src="https://github.com/user-attachments/assets/049cffa5-19d7-41be-94e4-8ff106fe5c45" />

The README.md file is then updated with a table.

## Also worth noting 

In most tests , the first two lines are for importing pandas and for creating the df. 
The other lines are the actual examples, therefore this is what gets inferred as being an example for that feature.
We can still control which example we want to show in the table by using the `example` argument inside the decorator. 

## Edit summary
- Add conftest.py to collect feature support status via pytest 
- Mark relevant tests with @pytest.mark.support for feature tracking 
-  Update README with a Supported Features table 
-  Add tabulate as a dev dependency for markdown table generation