### PR TITLE
Refactor diagnostic output formatting and add color support

### DIFF
--- a/frame-check-core/tests/test_diagnostic_output.py
+++ b/frame-check-core/tests/test_diagnostic_output.py
@@ -34,20 +34,21 @@ df["NonExistentColumn"]
     assert "  • Salary" in diag.hint
 
     # Call print_diagnostics and capture output
-    print_diagnostics(checker, "example.py")
+    print_diagnostics(checker, "example.py", color=False)
 
     # Read captured output
     captured = capfd.readouterr()
-    expected_output = f"""example.py:12:3 - error: Column 'NonExistentColumn' does not exist.
-  |
-12|df["NonExistentColumn"]
-  |  {"^" * 21}
-  |
-  | DataFrame 'df' created at line 10 with columns:
-  |   • Age
-  |   • City
-  |   • Name
-  |   • Salary
-  |
-"""
-    assert captured.out.strip() == expected_output.strip()
+    output = captured.out
+
+    # Test content instead of exact formatting
+    assert (
+        "example.py:12:3 - error: Column 'NonExistentColumn' does not exist." in output
+    )
+    assert 'df["NonExistentColumn"]' in output
+    assert "DataFrame 'df' created at line 10 with columns:" in output
+
+    # Check that all columns are listed in the output
+    assert "• Age" in output
+    assert "• City" in output
+    assert "• Name" in output
+    assert "• Salary" in output


### PR DESCRIPTION
- Add terminal color and formatting constants 
- Refactor print_diagnostics and helpers for clearer output 
- Add colorized output with option to disable via color argument 
- Update tests to check output content instead of exact formatting


## Before
<img width="1808" height="864" alt="image" src="https://github.com/user-attachments/assets/efaa8ce3-795d-4cb8-a28a-1f0f20788256" />


## After
<img width="1780" height="956" alt="image" src="https://github.com/user-attachments/assets/aa8ca350-89a3-4459-8f6d-ca1aa1e7fd79" />
