### PR TITLE
Remove unused fields

### DIFF
--- a/frame-check-core/src/frame_check_core/frame_checker.py
+++ b/frame-check-core/src/frame_check_core/frame_checker.py
@@ -122,8 +122,6 @@ class FrameChecker(ast.NodeVisitor):
                             id=node.targets[0].id
                             if isinstance(node.targets[0], ast.Name)
                             else "",
-                            data_arg=None,
-                            keywords=[],
                             columns=created.columns,
                         )
                         self.frames.add(new_frame)

--- a/frame-check-core/src/frame_check_core/models/history.py
+++ b/frame-check-core/src/frame_check_core/models/history.py
@@ -52,16 +52,6 @@ class FrameInstance:
     Identifier for the frame
     """
 
-    data_arg: ast.List | ast.Dict | None = None
-    """
-    Data argument used in the frame
-    """
-
-    keywords: list[ast.keyword] = field(default_factory=list)
-    """
-    Keyword arguments for the frame
-    """
-
     columns: frozenset[str]
     """
     Set of column names in this frame
@@ -73,8 +63,6 @@ class FrameInstance:
         *,
         region: CodeRegion,
         id: str,
-        data_arg: ast.List | ast.Dict | None = None,
-        keywords: list[ast.keyword] = field(default_factory=list),
         columns: Iterable[str] | ast.expr,
     ) -> "FrameInstance":
         """
@@ -83,7 +71,6 @@ class FrameInstance:
         Args:
             lineno: Line number where the frame appears
             id: Identifier for the frame
-            data_arg: Data argument used in the frame
             keywords: Keyword arguments for the frame
             columns: Column names to include in the frame
 
@@ -93,8 +80,6 @@ class FrameInstance:
         return cls(
             region=region,
             id=id,
-            data_arg=data_arg,
-            keywords=keywords,
             columns=frozenset(get_column_values(columns)),
             defined_region=region,
         )

--- a/frame-check-core/tests/test_frame_instance.py
+++ b/frame-check-core/tests/test_frame_instance.py
@@ -58,15 +58,11 @@ def test_frame_instance_new(columns, expected):
             end=(11, 2),
         ),
         id="df",
-        data_arg=None,
-        keywords=[],
         columns=columns,
     )
     assert frame.region.row_span == 1
     assert frame.region.col_span == 2
     assert frame.id == "df"
-    assert frame.data_arg is None
-    assert frame.keywords == []
     assert frame.columns == expected
 
 
@@ -77,8 +73,6 @@ def test_frame_instance_from_frame():
             end=(11, 2),
         ),
         id="df",
-        data_arg=None,
-        keywords=[],
         columns=["col_a", "col_b"],
     )
 
@@ -91,8 +85,6 @@ def test_frame_instance_from_frame():
     )
 
     assert new_frame.id == original_frame.id
-    assert new_frame.data_arg is original_frame.data_arg
-    assert new_frame.keywords == original_frame.keywords
     assert new_frame.columns == {"col_a", "col_b", "col_c", "col_d"}
     assert new_frame.region != original_frame.region
     assert new_frame.defined_region == original_frame.defined_region


### PR DESCRIPTION
Remove unused fields of `data_arg` and `keywords` which don't represent the state (point in time) of the dataframe but the construction. We can add it back when they are really necessary.