### PR TITLE
feat: add read_excel support (DCMS-9)

### DIFF
--- a/frame-check-core/src/frame_check_core/handlers/pandas.py
+++ b/frame-check-core/src/frame_check_core/handlers/pandas.py
@@ -18,8 +18,13 @@ def pd_dataframe(args: list[Result], keywords: dict[str, Result]) -> PDFuncResul
             return None, None
 
 
+# Note: both read_csv and read_excel have the same usecols handling
+# hence we can re-use the same function
 @PD.register("read_csv")
-def pd_read_csv(args: list[Result], keywords: dict[str, Result]) -> PDFuncResult:
+@PD.register("read_excel")
+def pd_read_csv_and_excel(
+    args: list[Result], keywords: dict[str, Result]
+) -> PDFuncResult:
     usecols = idx_or_key(args, keywords, key="usecols")
     match usecols:
         case str():

--- a/frame-check-core/tests/features/test_dataframe_creation_methods.py
+++ b/frame-check-core/tests/features/test_dataframe_creation_methods.py
@@ -78,3 +78,37 @@ df = pd.read_csv("{CSV_TEST_FILE}", usecols=cols)
     assert tracker is not None
     assert tracker.id_ == "df"
     assert set(tracker.columns.keys()) == {"a", "b", "c"}
+
+
+# --- DCMS-9: From excel ---
+
+
+@pytest.mark.support(code="#DCMS-9")
+def test_dcms_9_read_excel_usecols():
+    """pd.read_excel('file.csv', usecols=["a","b","c"])"""
+    code = f"""
+import pandas as pd
+df = pd.read_excel("{CSV_TEST_FILE}", usecols=["a", "b", "c"])
+"""
+    fc = Checker.check(code)
+    assert set(fc.dfs.keys()) == {"df"}
+    tracker = fc.dfs.get("df")
+    assert tracker is not None
+    assert tracker.id_ == "df"
+    assert set(tracker.columns.keys()) == {"a", "b", "c"}
+
+
+@pytest.mark.support(code="#DCMS-9-1")
+def test_dcms_9_1_read_excel_usecols_indirect():
+    """pd.read_excel with usecols from variable"""
+    code = f"""
+import pandas as pd
+cols = ['a', 'b', 'c']
+df = pd.read_excel("{CSV_TEST_FILE}", usecols=cols)
+"""
+    fc = Checker.check(code)
+    assert set(fc.dfs.keys()) == {"df"}
+    tracker = fc.dfs.get("df")
+    assert tracker is not None
+    assert tracker.id_ == "df"
+    assert set(tracker.columns.keys()) == {"a", "b", "c"}


### PR DESCRIPTION
Closes #161 
- Add pd.read_excel handler reusing read_csv logic
- Add tests for read_excel with usecols parameter
- Fix quote syntax in test file