### PR TITLE
chore(deps): squash dependabot updates v2

### DIFF
--- a/frame-check-lsp/pyproject.toml
+++ b/frame-check-lsp/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "frame-check-core",
-    "pygls==2.0.0a6",
+    "pygls==2.1.1",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,12 @@ dev = [
     "pytest-codspeed>=4.4.0",
     "tabulate>=0.10.0",
     "tomlkit>=0.13.3",
-    "types-psutil>=7.2.2.20260408",
+    "types-psutil>=7.2.2.20260508",
 ]
 docs = [
     "mkdocs-gen-files>=0.6.1",
     "mkdocs-material>=9.7.6",
-    "mkdocstrings[python]>=0.30.1",
+    "mkdocstrings[python]>=1.0.4",
     "pymdown-extensions>=10.21.2",
     "zensical>=0.0.36",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -398,12 +398,12 @@ dev = [
     { name = "pytest-codspeed", specifier = ">=4.4.0" },
     { name = "tabulate", specifier = ">=0.10.0" },
     { name = "tomlkit", specifier = ">=0.13.3" },
-    { name = "types-psutil", specifier = ">=7.2.2.20260408" },
+    { name = "types-psutil", specifier = ">=7.2.2.20260508" },
 ]
 docs = [
     { name = "mkdocs-gen-files", specifier = ">=0.6.1" },
     { name = "mkdocs-material", specifier = ">=9.7.6" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.30.1" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.4" },
     { name = "pymdown-extensions", specifier = ">=10.21.2" },
     { name = "zensical", specifier = ">=0.0.36" },
 ]
@@ -435,7 +435,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "frame-check-core", editable = "frame-check-core" },
-    { name = "pygls", specifier = "==2.0.0a6" },
+    { name = "pygls", specifier = "==2.1.1" },
 ]
 
 [[package]]
@@ -885,7 +885,7 @@ wheels = [
 
 [[package]]
 name = "mkdocstrings"
-version = "0.30.1"
+version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -895,9 +895,9 @@ dependencies = [
     { name = "mkdocs-autorefs" },
     { name = "pymdown-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/33/2fa3243439f794e685d3e694590d28469a9b8ea733af4b48c250a3ffc9a0/mkdocstrings-0.30.1.tar.gz", hash = "sha256:84a007aae9b707fb0aebfc9da23db4b26fc9ab562eb56e335e9ec480cb19744f", size = 106350, upload-time = "2025-09-19T10:49:26.446Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/5d/f888d4d3eb31359b327bc9b17a212d6ef03fe0b0682fbb3fc2cb849fb12b/mkdocstrings-1.0.4.tar.gz", hash = "sha256:3969a6515b77db65fd097b53c1b7aa4ae840bd71a2ee62a6a3e89503446d7172", size = 100088, upload-time = "2026-04-15T09:16:53.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/2c/f0dc4e1ee7f618f5bff7e05898d20bf8b6e7fa612038f768bfa295f136a4/mkdocstrings-0.30.1-py3-none-any.whl", hash = "sha256:41bd71f284ca4d44a668816193e4025c950b002252081e387433656ae9a70a82", size = 36704, upload-time = "2025-09-19T10:49:24.805Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/94/be70f8ee9c45f2f62b39a1f0e9303bc20e138a8f3b8e50ffd89498e177e1/mkdocstrings-1.0.4-py3-none-any.whl", hash = "sha256:63464b4b29053514f32a1dbbf604e52876d5e638111b0c295ab7ed3cac73ca9b", size = 35560, upload-time = "2026-04-15T09:16:51.436Z" },
 ]
 
 [package.optional-dependencies]
@@ -1289,16 +1289,16 @@ wheels = [
 
 [[package]]
 name = "pygls"
-version = "2.0.0a6"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "cattrs" },
     { name = "lsprotocol" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/42/270542357f5f52e0d7f4951d48b5a39efac6039810b5f9fb3ac9284e5cb8/pygls-2.0.0a6.tar.gz", hash = "sha256:1a94e0252e4bab607690e7dadbe949e1132a1e878325f5ad60c4936506188e49", size = 55930, upload-time = "2025-07-18T18:21:30.316Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/2e/7bbe061d175c0baddde8fc9edb908a4c31ba5d9165b8c68e3439c3a9f138/pygls-2.1.1.tar.gz", hash = "sha256:1da03ba9053201bb337dcdd8d121df70feb2a91e1a0dcc74de5da79755b1a201", size = 55091, upload-time = "2026-03-25T11:19:10.541Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/3b/8c83173e2afd7cb9b75201188c911b39f0b4dce09a3d0224dfc7f225290e/pygls-2.0.0a6-py3-none-any.whl", hash = "sha256:0a4a5f479a1554f8b493cfc4be5061344ae724f3959c51aedbf8c92174293233", size = 69574, upload-time = "2025-07-18T18:21:29.197Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1a/208293b6c350f5abea6941d5606080d4a492644052504f5312e5de30a902/pygls-2.1.1-py3-none-any.whl", hash = "sha256:510a6dea2476177230c7d851125e5948efdf3fdb9ebfd8543fc434972f8faed4", size = 68975, upload-time = "2026-03-25T11:19:11.374Z" },
 ]
 
 [[package]]
@@ -1622,11 +1622,11 @@ wheels = [
 
 [[package]]
 name = "types-psutil"
-version = "7.2.2.20260408"
+version = "7.2.2.20260508"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/44/14/279fd5defebbd560ede04aecd38f7651cccee7336f2264d0889d8c9a9d43/types_psutil-7.2.2.20260408.tar.gz", hash = "sha256:e8053450685965b8cd52afb62569073d00ea9967ae78bb45dff5f606847f97f2", size = 26556, upload-time = "2026-04-08T04:27:44.349Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/cc/5ac56357b08655ff93106d6391b72d50c47416a044041312550bcd806827/types_psutil-7.2.2.20260508.tar.gz", hash = "sha256:8cfd8339f5e898570f80486423e65d87558d89d0181bf723d20ac5e778fe218e", size = 26575, upload-time = "2026-05-08T04:46:48.388Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/40/2fd92a4a1ee088c4dbcc44c977908d9869838d9cd2a2fa2e001352f56694/types_psutil-7.2.2.20260408-py3-none-any.whl", hash = "sha256:0c334f6f6bc9e9c24fca5c7d1f0b6971c961a0a2e3956dc5ce704722c01f9762", size = 32861, upload-time = "2026-04-08T04:27:42.929Z" },
+    { url = "https://files.pythonhosted.org/packages/18/44/4467583df75313c28abaadfab12f102fba9db7285323e75601acf936d996/types_psutil-7.2.2.20260508-py3-none-any.whl", hash = "sha256:b142452e0953f2d07dbdbb98d81f3a629f5906cc2d94bb7e34da0fba55fbab4a", size = 32777, upload-time = "2026-05-08T04:46:46.972Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR combines multiple dependabot PRs into a single update:

- **PR #168**: Update mkdocstrings[python] from >=0.30.1 to >=1.0.4
- **PR #167**: Bump types-psutil from 7.2.2.20260408 to 7.2.2.20260508
- **PR #166**: Bump pygls from 2.0.0a6 to 2.1.1 in frame-check-lsp

## Changes

- Updated `pyproject.toml` (mkdocstrings and types-psutil)
- Updated `frame-check-lsp/pyproject.toml` (pygls)
- Regenerated `uv.lock` with all updates

## Dependabot PRs Squashed

Closes #166
Closes #167
Closes #168