### PR TITLE
feat: add dependabot grouping for smarter PR management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,31 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      docs:
+        patterns:
+          - "mkdocs*"
+          - "pymdown*"
+          - "mkdocstrings*"
+          - "zensical"
+          - "mkdocs-gen-files"
+      dev-tools:
+        patterns:
+          - "pytest*"
+          - "mypy"
+          - "pre-commit"
+          - "ipython*"
+          - "ipykernel*"
+          - "pandas*"
+          - "tabulate"
+          - "tomlkit"
+          - "types-*"
+
+  - package-ecosystem: "uv"
+    directory: "/frame-check-lsp"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Improve dependabot configuration to automatically group related dependency updates into fewer PRs.

## Changes to `.github/dependabot.yml`:

### New groups added:
- `docs` - Groups mkdocs*, pymdown*, mkdocstrings*, zensical, mkdocs-gen-files
- `dev-tools` - Groups pytest*, mypy, pre-commit, ipython*, ipykernel*, pandas*, tabulate, tomlkit, types-*

### Separate config:
- Added separate `package-ecosystem: "uv"` config for `/frame-check-lsp` directory with its own grouping

## Benefits:
- Fewer PRs: Related updates (e.g., all mkdocs-related) will be combined into single PRs
- Cleaner workflow: No more need to manually squash multiple dependabot PRs
- Better organization: Dev tools and docs dependencies are grouped logically

## Example:
Before: 3 separate PRs for mkdocs-material, mkdocstrings, pymdown-extensions
After: 1 combined PR for all docs-related updates