### PR TITLE
feat: add df.rename support (EC-2)

### DIFF
--- a/frame-check-core/src/frame_check_core/handlers/dataframe.py
+++ b/frame-check-core/src/frame_check_core/handlers/dataframe.py
@@ -17,3 +17,35 @@ def df_insert(
     if isinstance(column, str):
         columns.add(column)
     return columns, None, None
+
+
+@DF.register("rename")
+def df_rename(
+    columns: set[str], args: list[Result], keywords: dict[str, Result]
+) -> DFFuncResult:
+    col_mapping = idx_or_key(args, keywords, key="columns")
+
+    # Mapper+axis form: df.rename({"a": "b"}, axis=1) / axis="columns"
+    if not isinstance(col_mapping, dict):
+        axis = idx_or_key(args, keywords, idx=1, key="axis")
+        if axis == 1 or axis == "columns":
+            col_mapping = idx_or_key(args, keywords, idx=0, key="mapper")
+
+    inplace = idx_or_key(args, keywords, key="inplace")
+
+    if not isinstance(col_mapping, dict):
+        # Can't determine rename statically — leave columns untouched
+        if inplace is True:
+            return columns, None, None
+        return columns, columns, None
+
+    new_columns = set()
+    for col in columns:
+        if col in col_mapping and isinstance(col_mapping[col], str):
+            new_columns.add(col_mapping[col])
+        else:
+            new_columns.add(col)
+
+    if inplace is True:
+        return new_columns, None, None
+    return columns, new_columns, None

--- a/frame-check-core/src/frame_check_core/handlers/models.py
+++ b/frame-check-core/src/frame_check_core/handlers/models.py
@@ -9,7 +9,7 @@ class _Unknown:
 
 
 Unknown = _Unknown()  # A value that is either not supported or not provided.
-Result = Union[str, dict, list, "PD", "PDMethod", "DF", "DFMethod", _Unknown]
+Result = Union[str, bool, int, dict, list, "PD", "PDMethod", "DF", "DFMethod", _Unknown]
 
 _ASSIGNING_ATTR = "_frame_checker_assigning"
 _RESULT_ATTR = "_frame_checker_result_columns"
@@ -26,6 +26,13 @@ def set_assigning(node: ast.Subscript) -> None:
 def get_value(node: ast.AST, definitions: dict[str, Result]) -> Result:
     match node:
         case ast.Constant(value=str(result)):
+            return result
+
+        # bool must precede int — bool is a subclass of int
+        case ast.Constant(value=bool(result)):
+            return result
+
+        case ast.Constant(value=int(result)):
             return result
 
         case ast.List(elts=elts):

--- a/frame-check-core/tests/features/test_edge_cases.py
+++ b/frame-check-core/tests/features/test_edge_cases.py
@@ -1,0 +1,128 @@
+"""Feature tests for Edge Cases (EC)."""
+
+import pytest
+from frame_check_core.checker import Checker
+
+# --- EC-2: Rename operation ---
+
+
+@pytest.mark.support(code="#EC-2")
+def test_ec_2_rename_operation_columns():
+    """df.rename"""
+    code = """
+import pandas as pd
+df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+df = df.rename(columns={'col1': 'cola', 'col2': 'colb'})
+df['cola']
+df['colb']
+"""
+    fc = Checker.check(code)
+    df = fc.dfs.get("df")
+    assert df is not None
+    assert set(df.columns.keys()) == {"cola", "colb"}
+    assert len(fc.diagnostics) == 0
+
+
+@pytest.mark.support(code="#EC-2-1")
+@pytest.mark.xfail(reason="Standalone method calls not implemented", strict=True)
+def test_ec_2_1_rename_inplace():
+    """df.rename(columns=..., inplace=True)"""
+    code = """
+import pandas as pd
+df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+df.rename(columns={'col1': 'cola'}, inplace=True)
+df['cola']
+df['col2']
+"""
+    fc = Checker.check(code)
+    df = fc.dfs.get("df")
+    assert df is not None
+    assert set(df.columns.keys()) == {"cola", "col2"}
+    assert len(fc.diagnostics) == 0
+
+
+@pytest.mark.support(code="#EC-2-2")
+def test_ec_2_2_rename_mapper_axis_int():
+    """df.rename({...}, axis=1)"""
+    code = """
+import pandas as pd
+df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+df = df.rename({'col1': 'cola'}, axis=1)
+df['cola']
+df['col2']
+"""
+    fc = Checker.check(code)
+    df = fc.dfs.get("df")
+    assert df is not None
+    assert set(df.columns.keys()) == {"cola", "col2"}
+    assert len(fc.diagnostics) == 0
+
+
+@pytest.mark.support(code="#EC-2-3")
+def test_ec_2_3_rename_mapper_axis_columns_str():
+    """df.rename({...}, axis='columns')"""
+    code = """
+import pandas as pd
+df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+df = df.rename({'col1': 'cola'}, axis='columns')
+df['cola']
+"""
+    fc = Checker.check(code)
+    df = fc.dfs.get("df")
+    assert df is not None
+    assert set(df.columns.keys()) == {"cola", "col2"}
+    assert len(fc.diagnostics) == 0
+
+
+@pytest.mark.support(code="#EC-2-4")
+def test_ec_2_4_rename_index_only_leaves_columns():
+    """df.rename(index={...}) must not touch columns"""
+    code = """
+import pandas as pd
+df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+df = df.rename(index={0: 'first'})
+df['col1']
+df['col2']
+"""
+    fc = Checker.check(code)
+    df = fc.dfs.get("df")
+    assert df is not None
+    assert set(df.columns.keys()) == {"col1", "col2"}
+    assert len(fc.diagnostics) == 0
+
+
+@pytest.mark.support(code="#EC-2-5")
+def test_ec_2_5_rename_nonexistent_column_is_noop():
+    """Renaming a key not in df.columns leaves df unchanged (errors='ignore' default)."""
+    code = """
+import pandas as pd
+df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+df = df.rename(columns={'missing': 'whatever'})
+df['col1']
+df['col2']
+"""
+    fc = Checker.check(code)
+    df = fc.dfs.get("df")
+    assert df is not None
+    assert set(df.columns.keys()) == {"col1", "col2"}
+    assert len(fc.diagnostics) == 0
+
+
+@pytest.mark.support(code="#EC-2-6")
+def test_ec_2_6_rename_with_opaque_mapping_no_false_positives():
+    """When the mapping can't be resolved statically, columns are left untouched
+    and access to existing columns must still pass."""
+    code = """
+import pandas as pd
+import json
+df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+mapping = json.loads('{"col1": "cola"}')
+df = df.rename(columns=mapping)
+df['col1']
+df['col2']
+"""
+    fc = Checker.check(code)
+    df = fc.dfs.get("df")
+    assert df is not None
+    assert set(df.columns.keys()) == {"col1", "col2"}
+    assert len(fc.diagnostics) == 0


### PR DESCRIPTION
## Summary
- Adds a DataFrame method handler for df.rename covering the columns kwarg, the mapper+axis form (axis=1 and axis="columns"), inplace=True, index-only renames (no-op on columns), and opaque mappings (no false positives).
- Extends get_value to resolve bool and int constants — without this, inplace=True and axis=1 silently resolved to Unknown.
- Adds 6 new tests under EC-2 (one xfail for standalone inplace calls, matching CAM-9's "standalone method calls not implemented" gap).

## Test plan
- [x] uv run pytest tests/ — 146 passed, 4 xfailed
- [x] EC-2 happy path, mapper+axis (int and str), index-only, missing-key no-op, opaque mapping